### PR TITLE
INTIJC-2: adding unit test for JenkinsProxyHelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     testCompile 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
     testCompile 'org.mockito:mockito-junit-jupiter:3.3.3'
+
+    testRuntime 'javax.servlet:javax.servlet-api:4.0.1'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compileOnly 'org.jenkins-ci.plugins:plain-credentials:1.0@jar'
 
     testCompile 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.6.2'
     testCompile 'org.mockito:mockito-junit-jupiter:3.3.3'
 
     testRuntime 'javax.servlet:javax.servlet-api:4.0.1'

--- a/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
@@ -2,10 +2,12 @@ package com.synopsys.integration.jenkins;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -18,60 +20,73 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 
 public class JenkinsProxyHelperTest {
 
-    ProxyInfo proxyInfo;
-
-    static String includeHost = "www.include.com";
-    static String excludeHost = "www.exclude.com";
-
-    static Pattern includePattern = Pattern.compile(includeHost);
-    static Pattern excludePattern = Pattern.compile(excludeHost);
-
-    static final String url = "https://" + includeHost;
     final String proxyHost = "proxyHost";
     final String proxyUsername = "proxyUsername";
     final String proxyPassword = "proxyPassword";
     final String ntlmDomain = "ntlmDomain";
     final String ntlmWorkstation = "ntlmWorkstation";
+    final int proxyPort = 13;
 
     private static Stream<Arguments> populateNoProxyInfoTests() {
-        List<Pattern> patterns = new ArrayList<>();
-        patterns.add(includePattern);
+        String hostToExclude = "www.exclude.com";
+        Pattern hostExcludePattern = Pattern.compile(hostToExclude);
+        List<Pattern> ignoredProxyHosts = new ArrayList<>();
+        ignoredProxyHosts.add(hostExcludePattern);
+
         return Stream.of(
-            Arguments.of("", patterns),
-            Arguments.of(null, patterns),
-            Arguments.of(url, patterns)
+            Arguments.of("", ignoredProxyHosts),
+            Arguments.of(null, ignoredProxyHosts),
+            Arguments.of("https://" + hostToExclude, ignoredProxyHosts)
         );
     }
 
     private static Stream<Arguments> populateValidProxyInfoTests() {
+        String hostToInclude = "https://www.include.com";
+        String hostToExclude = "www.exclude.com";
+        Pattern hostExcludePattern = Pattern.compile(hostToExclude);
+
         return Stream.of(
-            Arguments.of(url, new ArrayList<>()),
-            Arguments.of(url, null),
-            Arguments.of(url, Arrays.asList(excludePattern))
+            Arguments.of(hostToInclude, new ArrayList<>()),
+            Arguments.of(hostToInclude, null),
+            Arguments.of(hostToInclude, Arrays.asList(hostExcludePattern))
         );
     }
 
     @ParameterizedTest
     @MethodSource("populateNoProxyInfoTests")
-    public void testGetProxyInfo_NoProxyInfo(String inputUrl, List<Pattern> ignorePatterns) {
+    public void testGetProxyInfo_NoProxyInfo(String url, List<Pattern> ignoredProxyHosts) {
         // The returned proxyInfo object should be equal to ProxyInfo.NO_PROXY_INFO
-        proxyInfo = JenkinsProxyHelper.getProxyInfo(inputUrl, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, ignorePatterns, ntlmDomain, ntlmWorkstation);
-        assertFalse(proxyInfo.getHost().isPresent());
-        assertEquals(0, proxyInfo.getPort());
+        ProxyInfo proxyInfo = JenkinsProxyHelper.getProxyInfo(url, proxyHost, proxyPort, proxyUsername, proxyPassword, ignoredProxyHosts, ntlmDomain, ntlmWorkstation);
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxy().isPresent(), proxyInfo.getProxy().isPresent());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getHost().isPresent(), proxyInfo.getHost().isPresent());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getPort(), proxyInfo.getPort());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxyCredentials().isPresent(), proxyInfo.getProxyCredentials().isPresent());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getUsername(), proxyInfo.getUsername());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getPassword(), proxyInfo.getPassword());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getNtlmDomain(), proxyInfo.getNtlmDomain());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getNtlmWorkstation(), proxyInfo.getNtlmWorkstation());
     }
 
     @ParameterizedTest
     @MethodSource("populateValidProxyInfoTests")
-    public void testGetProxyInfo_PopulatedProxyInfo(String inputUrl, List<Pattern> ignorePatterns) {
+    public void testGetProxyInfo_PopulatedProxyInfo(String url, List<Pattern> ignoredProxyHosts) {
         // The returned proxyInfo object should be populated with the values supplied to getProxyInfo
-        proxyInfo = JenkinsProxyHelper.getProxyInfo(inputUrl, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, ignorePatterns, ntlmDomain, ntlmWorkstation);
+        ProxyInfo proxyInfo = JenkinsProxyHelper.getProxyInfo(url, proxyHost, proxyPort, proxyUsername, proxyPassword, ignoredProxyHosts, ntlmDomain, ntlmWorkstation);
+        assertTrue(proxyInfo.getProxy().isPresent());
+        assertTrue(proxyInfo.getHost().isPresent());
         assertEquals(proxyHost, proxyInfo.getHost().orElse(null));
-        assertEquals(Integer.MAX_VALUE, proxyInfo.getPort());
+        assertEquals(proxyPort, proxyInfo.getPort());
+        assertTrue(proxyInfo.getProxyCredentials().isPresent());
+        assertEquals(Optional.of(proxyUsername), proxyInfo.getUsername());
+        assertEquals(Optional.of(proxyPassword), proxyInfo.getPassword());
+        assertEquals(Optional.of(ntlmDomain), proxyInfo.getNtlmDomain());
+        assertEquals(Optional.of(ntlmWorkstation), proxyInfo.getNtlmWorkstation());
     }
 
     @Test
     public void testGetProxyInfoFromJenkins_NullJenkins() {
-        proxyInfo = JenkinsProxyHelper.getProxyInfoFromJenkins(url);
+        String url = "https://www.exclude.com";
+        ProxyInfo proxyInfo = JenkinsProxyHelper.getProxyInfoFromJenkins(url);
         assertFalse(proxyInfo.getHost().isPresent());
         assertEquals(0, proxyInfo.getPort());
     }

--- a/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -57,10 +56,10 @@ public class JenkinsProxyHelperTest {
     public void testGetProxyInfo_NoProxyInfo(String url, List<Pattern> ignoredProxyHosts) {
         // The returned proxyInfo object should be equal to ProxyInfo.NO_PROXY_INFO
         ProxyInfo proxyInfo = JenkinsProxyHelper.getProxyInfo(url, proxyHost, proxyPort, proxyUsername, proxyPassword, ignoredProxyHosts, ntlmDomain, ntlmWorkstation);
-        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxy().isPresent(), proxyInfo.getProxy().isPresent());
-        assertEquals(ProxyInfo.NO_PROXY_INFO.getHost().isPresent(), proxyInfo.getHost().isPresent());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxy(), proxyInfo.getProxy());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getHost(), proxyInfo.getHost());
         assertEquals(ProxyInfo.NO_PROXY_INFO.getPort(), proxyInfo.getPort());
-        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxyCredentials().isPresent(), proxyInfo.getProxyCredentials().isPresent());
+        assertEquals(ProxyInfo.NO_PROXY_INFO.getProxyCredentials(), proxyInfo.getProxyCredentials());
         assertEquals(ProxyInfo.NO_PROXY_INFO.getUsername(), proxyInfo.getUsername());
         assertEquals(ProxyInfo.NO_PROXY_INFO.getPassword(), proxyInfo.getPassword());
         assertEquals(ProxyInfo.NO_PROXY_INFO.getNtlmDomain(), proxyInfo.getNtlmDomain());
@@ -74,13 +73,13 @@ public class JenkinsProxyHelperTest {
         ProxyInfo proxyInfo = JenkinsProxyHelper.getProxyInfo(url, proxyHost, proxyPort, proxyUsername, proxyPassword, ignoredProxyHosts, ntlmDomain, ntlmWorkstation);
         assertTrue(proxyInfo.getProxy().isPresent());
         assertTrue(proxyInfo.getHost().isPresent());
-        assertEquals(proxyHost, proxyInfo.getHost().orElse(null));
+        assertEquals(proxyHost, proxyInfo.getHost().get());
         assertEquals(proxyPort, proxyInfo.getPort());
         assertTrue(proxyInfo.getProxyCredentials().isPresent());
-        assertEquals(Optional.of(proxyUsername), proxyInfo.getUsername());
-        assertEquals(Optional.of(proxyPassword), proxyInfo.getPassword());
-        assertEquals(Optional.of(ntlmDomain), proxyInfo.getNtlmDomain());
-        assertEquals(Optional.of(ntlmWorkstation), proxyInfo.getNtlmWorkstation());
+        assertEquals(proxyUsername, proxyInfo.getUsername().get());
+        assertEquals(proxyPassword, proxyInfo.getPassword().get());
+        assertEquals(ntlmDomain, proxyInfo.getNtlmDomain().get());
+        assertEquals(ntlmWorkstation, proxyInfo.getNtlmWorkstation().get());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/JenkinsProxyHelperTest.java
@@ -1,0 +1,95 @@
+package com.synopsys.integration.jenkins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+
+public class JenkinsProxyHelperTest {
+
+    ProxyInfo proxyInfo;
+    List<Pattern> patterns = new ArrayList<>();
+
+    final String url_1 = "www.include.com";
+    final String url_2 = "www.exclude.com";
+
+    Pattern pattern_1 = Pattern.compile(url_1);
+    Pattern pattern_2 = Pattern.compile(url_2);
+
+    final String protocol = "https://";
+    final String proxyHost = "proxyHost";
+    final String proxyUsername = "proxyUsername";
+    final String proxyPassword = "proxyPassword";
+    final String ntlmDomain = "ntlmDomain";
+    final String ntlmWorkstation = "ntlmWorkstation";
+
+    @Test
+    public void testGetProxyInfoFromJenkins_NullJenkins() {
+        proxyInfo = JenkinsProxyHelper.getProxyInfoFromJenkins(protocol + url_1);
+        assertFalse(proxyInfo.getHost().isPresent());
+        assertEquals(0, proxyInfo.getPort());
+    }
+
+    @Test
+    public void testGetProxyInfo_EmptyUrlMatchingExclude() {
+        // The returning proxyInfo object should be equal to ProxyInfo.NO_PROXY_INFO
+        patterns.clear();
+        patterns.add(pattern_1);
+        proxyInfo = JenkinsProxyHelper.getProxyInfo("", proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, patterns, ntlmDomain, ntlmWorkstation);
+        assertFalse(proxyInfo.getHost().isPresent());
+        assertEquals(0, proxyInfo.getPort());
+    }
+
+    @Test
+    public void testGetProxyInfo_NullUrlMatchingExclude() {
+        // The returning proxyInfo object should be equal to ProxyInfo.NO_PROXY_INFO
+        patterns.clear();
+        patterns.add(pattern_1);
+        proxyInfo = JenkinsProxyHelper.getProxyInfo(null, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, patterns, ntlmDomain, ntlmWorkstation);
+        assertFalse(proxyInfo.getHost().isPresent());
+        assertEquals(0, proxyInfo.getPort());
+    }
+
+    @Test
+    public void testGetProxyInfo_ValidUrlMatchingExclude() {
+        // The returning proxyInfo object should be equal to ProxyInfo.NO_PROXY_INFO
+        patterns.clear();
+        patterns.add(pattern_1);
+        proxyInfo = JenkinsProxyHelper.getProxyInfo(protocol + url_1, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, patterns, ntlmDomain, ntlmWorkstation);
+        assertFalse(proxyInfo.getHost().isPresent());
+        assertEquals(0, proxyInfo.getPort());
+    }
+
+    @Test
+    public void testGetProxyInfo_ValidUrlEmptyExclude() {
+        // The returning proxyInfo object should be populated with the values supplied to getProxyInfo
+        patterns.clear();
+        proxyInfo = JenkinsProxyHelper.getProxyInfo(protocol + url_1, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, patterns, ntlmDomain, ntlmWorkstation);
+        assertEquals(proxyHost, proxyInfo.getHost().orElse(null));
+        assertEquals(Integer.MAX_VALUE, proxyInfo.getPort());
+    }
+
+    @Test
+    public void testGetProxyInfo_ValidUrlNullExclude() {
+        // The returning proxyInfo object should be populated with the values supplied to getProxyInfo
+        proxyInfo = JenkinsProxyHelper.getProxyInfo(protocol + url_1, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, null, ntlmDomain, ntlmWorkstation);
+        assertEquals(proxyUsername, proxyInfo.getUsername().orElse(null));
+        assertEquals(proxyPassword, proxyInfo.getPassword().orElse(null));
+    }
+
+    @Test
+    public void testGetProxyInfo_ValidUrlNonMatchingExclude() {
+        // The returning proxyInfo object should be populated with the values supplied to getProxyInfo
+        patterns.clear();
+        patterns.add(pattern_2);
+        proxyInfo = JenkinsProxyHelper.getProxyInfo(protocol + url_1, proxyHost, Integer.MAX_VALUE, proxyUsername, proxyPassword, patterns, ntlmDomain, ntlmWorkstation);
+        assertEquals(ntlmDomain, proxyInfo.getNtlmDomain().orElse(null));
+        assertEquals(ntlmWorkstation, proxyInfo.getNtlmWorkstation().orElse(null));
+    }
+}


### PR DESCRIPTION
Initial add of unit tests for JenkinsProxyHelper

Complete coverage for JenkinsProxyHelper.getProxyInfoFromJenkins will be discussed and handled in a separate PR.