### PR TITLE
INTIJC-7 - Refactor of JenkinsProxyHelper to provide instance methods

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/JenkinsProxyHelper.java
+++ b/src/main/java/com/synopsys/integration/jenkins/JenkinsProxyHelper.java
@@ -83,8 +83,6 @@ public class JenkinsProxyHelper {
             proxyInfoBuilder.setNtlmWorkstation(StringUtils.trimToNull(ntlmWorkstation));
 
             proxyInfo = proxyInfoBuilder.build();
-        } else {
-            proxyInfo = ProxyInfo.NO_PROXY_INFO;
         }
 
         return proxyInfo;


### PR DESCRIPTION
Refactor of JenkinsProxyHelper to provide instance methods and deprecate, or possibly remove, static methods.

The user will now be required to provide a valid ProxyConfiguration object as a parameter OR all of the values that would be part of a ProxyConfiguration object. Regardless of which constructor is called, both will leverage getProxyInfo() to return an instance of ProxyInfo.

NOTE: All tests within https://github.com/synopsys-sig/jenkins-common/pull/4 were run successfully in my local environment. These tests are only for the static methods. If the statics methods are moved vs deprecated, that PR will be closed and the branch removed.