### PR TITLE
Dev/jpp/master/jenkins upgrade - proposed changes for jenkins-common lib.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,18 +38,13 @@ dependencies {
     // core version bump
     implementation 'org.jenkins-ci.main:jenkins-core:2.334'
 
-    //implementation 'org.jenkins-ci.plugins:credentials:2.3.12@jar'
-    //implementation 'org.jenkins-ci.plugins:credentials:2.3.12'
-    //implementation 'org.jenkins-ci.plugins:plain-credentials:1.7@jar'
-    //implementation 'org.jenkins-ci.plugins:plain-credentials:1.7'
-
+    // the following versions are compatible/usable in jenkins core 2.334 and later apparently.
     implementation 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040e4@jar'
-    implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b@jar'
     implementation 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b@jar'
     implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
-
-    implementation 'org.jenkins-ci.plugins.workflow:workflow-support:3.5@jar'
-    implementation 'org.jenkins-ci.plugins.workflow:workflow-support:3.5'
-    implementation 'org.jenkins-ci.plugins.workflow:workflow-api:2.40@jar'
-    implementation 'org.jenkins-ci.plugins.workflow:workflow-api:2.40'
+    implementation 'org.jenkins-ci.plugins.workflow:workflow-support:815.vd60466279fc8@jar'
+    implementation 'org.jenkins-ci.plugins.workflow:workflow-support:815.vd60466279fc8'
+    implementation 'org.jenkins-ci.plugins.workflow:workflow-api:1143.v2d42f1e9dea_5@jar'
+    implementation 'org.jenkins-ci.plugins.workflow:workflow-api:1143.v2d42f1e9dea_5'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,20 @@ dependencies {
     // or Jenkins plugin versions in Jenkins plugins that depend on this library.
     // Jenkins plugins that depend on this library should therefore version those dependencies compatibly with the versions below:
     // --rotte DEC 2019
+
+    // core version bump
     implementation 'org.jenkins-ci.main:jenkins-core:2.334'
-    implementation 'org.jenkins-ci.plugins:credentials:2.3.12@jar'
-    implementation 'org.jenkins-ci.plugins:credentials:2.3.12'
-    implementation 'org.jenkins-ci.plugins:plain-credentials:1.7@jar'
-    implementation 'org.jenkins-ci.plugins:plain-credentials:1.7'
+
+    //implementation 'org.jenkins-ci.plugins:credentials:2.3.12@jar'
+    //implementation 'org.jenkins-ci.plugins:credentials:2.3.12'
+    //implementation 'org.jenkins-ci.plugins:plain-credentials:1.7@jar'
+    //implementation 'org.jenkins-ci.plugins:plain-credentials:1.7'
+
+    implementation 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040e4@jar'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b@jar'
+    implementation 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
+
     implementation 'org.jenkins-ci.plugins.workflow:workflow-support:3.5@jar'
     implementation 'org.jenkins-ci.plugins.workflow:workflow-support:3.5'
     implementation 'org.jenkins-ci.plugins.workflow:workflow-api:2.40@jar'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.jenkins-common'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '0.5.4'
+version = '0.5.4-SNAPSHOT'
 description = 'Library for common Synopsys Jenkins plugin logic'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.jenkins-common'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '0.5.4-SNAPSHOT'
+version = '0.5.4'
 description = 'Library for common Synopsys Jenkins plugin logic'
 
 apply plugin: 'com.synopsys.integration.library'
@@ -34,7 +34,7 @@ dependencies {
     // or Jenkins plugin versions in Jenkins plugins that depend on this library.
     // Jenkins plugins that depend on this library should therefore version those dependencies compatibly with the versions below:
     // --rotte DEC 2019
-    implementation 'org.jenkins-ci.main:jenkins-core:2.248'
+    implementation 'org.jenkins-ci.main:jenkins-core:2.334'
     implementation 'org.jenkins-ci.plugins:credentials:2.3.12@jar'
     implementation 'org.jenkins-ci.plugins:credentials:2.3.12'
     implementation 'org.jenkins-ci.plugins:plain-credentials:1.7@jar'


### PR DESCRIPTION
The following changes in this library:
version bump to 0.5.4

jenkins-core version bumped to 2.334

The following definitions appear to be functional with the core version specified, and as such, the following plugin versions are proposed:
    'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040'
    'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
    'org.jenkins-ci.plugins.workflow:workflow-support:815.vd60466279fc8'
    'org.jenkins-ci.plugins.workflow:workflow-api:1143.v2d42f1e9dea_5'

Plugins that depend on this library will need to ensure that any of the above jenkins plugins consumed, must match in said plugin.

NOTE: These changes were tested in a jenkins v2.334 docker install.